### PR TITLE
generalize and unify geometry representations

### DIFF
--- a/API.md
+++ b/API.md
@@ -235,20 +235,19 @@ invalidAction = 203 // whatever the client is trying to do is impossible, e.g. r
 * hex string, #RRGGBB, capitalized. e.g. `#BB0044`
 
 
-## `Point`
+## `Vector`
 ```
 x: Double
 y: Double
 ```
 
-## `Frame`
-origin is top left
+
+## `Rectangle`
 ```
-startX: Double
-startY: Double
-height: Double
-width: Double
+origin: Vector
+size: Vector
 ```
+
 
 ## `File`
 ```
@@ -307,7 +306,7 @@ trade: String // e.g. "Gipser", "Maler"
 meta: ObjectMeta
 children: [UUID]
 sectors: [Sector]
-sectorFrame: Frame?
+sectorFrame: Rectangle?
 issues: [UUID]
 file: File?
 name: String
@@ -319,7 +318,7 @@ name: String
 ```
 name: String
 color: Color
-points: [Point]
+points: [Vector]
 ```
 
 
@@ -337,12 +336,14 @@ status: Status
 position: Position?
 ```
 
+
 ### `Issue.Position`
 ```
-point: Point
+point: Vector
 zoomScale: Double
 mapFileId: UUID
 ```
+
 
 ### `Issue.Status`
 * status of an issue
@@ -352,6 +353,7 @@ registration: Event? // registration in issue collection
 response: Event? // response from craftsman
 review: Event? // review by supervisor
 ```
+
 
 #### `Issue.Status.Event`
 * details about when an issue's status was changed and by whom

--- a/API.md
+++ b/API.md
@@ -243,6 +243,7 @@ y: Double
 
 
 ## `Rectangle`
+The origin is in the top left; the 4 corners would be at `(origin.x, origin.y)`, `(origin.x, origin.y + size.y)`, `(origin.x + size.x, origin.y + size.y)`, `(origin.x + size.x, origin.y)`
 ```
 origin: Vector
 size: Vector

--- a/API.md
+++ b/API.md
@@ -235,7 +235,7 @@ invalidAction = 203 // whatever the client is trying to do is impossible, e.g. r
 * hex string, #RRGGBB, capitalized. e.g. `#BB0044`
 
 
-## `Vector`
+## `Point`
 ```
 x: Double
 y: Double
@@ -243,17 +243,18 @@ y: Double
 
 
 ## `Rectangle`
-The origin is in the top left; the 4 corners would be at `(origin.x, origin.y)`, `(origin.x, origin.y + size.y)`, `(origin.x + size.x, origin.y + size.y)`, `(origin.x + size.x, origin.y)`
+The origin is in the top left; the 4 corners would be at `(origin.x, origin.y)`, `(origin.x, origin.y + height)`, `(origin.x + width, origin.y + height)`, `(origin.x + width, origin.y)`
 ```
-origin: Vector
-size: Vector
+origin: Point
+width: Double
+height: Double
 ```
 
 
 ## `File`
 ```
 id: UUID
-filename: string
+filename: String
 ```
 
 
@@ -319,7 +320,7 @@ name: String
 ```
 name: String
 color: Color
-points: [Vector]
+points: [Point]
 ```
 
 
@@ -340,7 +341,7 @@ position: Position?
 
 ### `Issue.Position`
 ```
-point: Vector
+point: Point
 zoomScale: Double
 mapFileId: UUID
 ```


### PR DESCRIPTION
`Frame` doesn't really represent any more data than a `Rectangle` would, and `Point`s are really just `Vector`s, so I renamed both and changed `Rectangle` to use `Vector`s for its location and size.