### PR TITLE
add a `/trial` request

### DIFF
--- a/API.md
+++ b/API.md
@@ -17,6 +17,19 @@
 # Methods
 
 
+## `/trial`
+* creates a new account with some sample data, as a trial, returning the credentials.
+
+##### request:
+empty
+
+##### response:
+```
+username: String
+password: String
+```
+
+
 ## `/login`
 * returned token should be kept alive for as long as possible, even supporting multiple logged in devices
 


### PR DESCRIPTION
As discussed today, we should have a way for users to try out the app easily. This is the API addition that requires.